### PR TITLE
Nu virker både JavaFX og FXGL

### DIFF
--- a/.idea/libraries/com_github_almasb_fxgl_0_5_4.xml
+++ b/.idea/libraries/com_github_almasb_fxgl_0_5_4.xml
@@ -1,0 +1,32 @@
+<component name="libraryTable">
+  <library name="com.github.almasb:fxgl:0.5.4" type="repository">
+    <properties maven-id="com.github.almasb:fxgl:0.5.4" />
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/almasb/FXGL/0.5.4/fxgl-0.5.4.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/almasb/fxgl-base/0.5.4/fxgl-base-0.5.4.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-coroutines-core/0.23.4/kotlinx-coroutines-core-0.23.4.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/kotlinx-coroutines-core-common/0.23.4/kotlinx-coroutines-core-common-0.23.4.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlinx/atomicfu-common/0.10.3/atomicfu-common-0.10.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-databind/2.9.0/jackson-databind-2.9.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-annotations/2.9.0/jackson-annotations-2.9.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.9.0/jackson-core-2.9.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/fasterxml/jackson/module/jackson-module-kotlin/2.9.0/jackson-module-kotlin-2.9.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-reflect/1.1.3/kotlin-reflect-1.1.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpclient/4.5.3/httpclient-4.5.3.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/apache/httpcomponents/httpcore/4.4.6/httpcore-4.4.6.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/commons-logging/commons-logging/1.2/commons-logging-1.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/commons-codec/commons-codec/1.9/commons-codec-1.9.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/gluonhq/charm-down-plugin-storage/3.7.0/charm-down-plugin-storage-3.7.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/gluonhq/charm-down-core/3.7.0/charm-down-core-3.7.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/gluonhq/charm-down-plugin-storage-desktop/3.7.0/charm-down-plugin-storage-desktop-3.7.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/gluonhq/charm-down-plugin-lifecycle/3.7.0/charm-down-plugin-lifecycle-3.7.0.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/almasb/fxgl-plugin-audio/0.0.2/fxgl-plugin-audio-0.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/com/github/almasb/fxgl-plugin-audio-desktop/0.0.2/fxgl-plugin-audio-desktop-0.0.2.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib/1.2.51/kotlin-stdlib-1.2.51.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/kotlin/kotlin-stdlib-common/1.2.51/kotlin-stdlib-common-1.2.51.jar!/" />
+      <root url="jar://$MAVEN_REPOSITORY$/org/jetbrains/annotations/13.0/annotations-13.0.jar!/" />
+    </CLASSES>
+    <JAVADOC />
+    <SOURCES />
+  </library>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_10" default="true" project-jdk-name="10" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Luigi.iml
+++ b/Luigi.iml
@@ -16,5 +16,6 @@
     <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-reflect:1.1.3" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains.kotlin:kotlin-stdlib:1.1.3" level="project" />
     <orderEntry type="library" name="Maven: org.jetbrains:annotations:13.0" level="project" />
+    <orderEntry type="library" name="com.github.almasb:fxgl:0.5.4" level="project" />
   </component>
 </module>


### PR DESCRIPTION
Sådan gjorde jeg: 

**For at fixe fejlen med JavaFX, kan du bruge Java 8 i stedet for Java 10.** 
— Gå ind på File —> Project Structure —> Project
— Project SDK sættes til 1.8 (download, hvis ikke du har det)
— Project language level sættes til SDK Default eller 8. 

**For at fixe fejlen med FXGL, skal du tilføje FXGL som et extern library.** 
— Gå ind på File —> Project Structure —> Libraries
— Klik på plus (+)
— Du kan enten downloade FXGL og tilføje den lokalt eller bruge Maven. Her skal du vælge Maven efter at du klikket +, og skrive "com.github.almasb:fxgl:0.5.4” i feltet. (Være tålmodig, denne del er langsom!) 